### PR TITLE
Add livenessProbe to handle automatic pod restarts

### DIFF
--- a/charts/codimd/templates/deployment.yaml
+++ b/charts/codimd/templates/deployment.yaml
@@ -163,6 +163,16 @@ spec:
             successThreshold: 3
             timeoutSeconds: 2
             periodSeconds: 5
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /status
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 2
       restartPolicy: Always
       {{ if .Values.codimd.imageStorePersistentVolume.enabled }}
       volumes:


### PR DESCRIPTION
The current deployment doesn't have a livenessProbe which can lead to the states where the pod is ready but does no longer accept requests. Probing the container for liveness will automatically restart it.

I copied the defaults from the readinessProbe but you might want to adjust it to some better suited defaults.