### PR TITLE
fix indentation of livenessprobe

### DIFF
--- a/charts/codimd/Chart.yaml
+++ b/charts/codimd/Chart.yaml
@@ -18,7 +18,7 @@ kubeVersion: ">=1.14.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/codimd/templates/deployment.yaml
+++ b/charts/codimd/templates/deployment.yaml
@@ -163,16 +163,16 @@ spec:
             successThreshold: 3
             timeoutSeconds: 2
             periodSeconds: 5
-        livenessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /status
-            port: 3000
-            scheme: HTTP
-          initialDelaySeconds: 3
-          periodSeconds: 5
-          successThreshold: 1
-          timeoutSeconds: 2
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /status
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 3
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 2
       restartPolicy: Always
       {{ if .Values.codimd.imageStorePersistentVolume.enabled }}
       volumes:


### PR DESCRIPTION
I was not able to deploy 0.1.9 in ArgoCD because the lint failed.

This has been introduced in https://github.com/hackmdio/codimd-helm/commit/b0a50b62d83e46ab50d93827d02eb991d9eac618
but a helm lint was not successful. With more indentation, helm seems to be happy now.
