### PR TITLE
`codimd.extraEnvironmentVariablesFrom` to support passing `{configMap,secretKey}Ref` as environment variables

### DIFF
--- a/charts/codimd/Chart.yaml
+++ b/charts/codimd/Chart.yaml
@@ -23,3 +23,10 @@ version: 0.1.11
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.3.2
+
+annotations:
+  artifacthub.io/changes: |
+    - "Add 'codimd.extraEnvironmentVariablesFrom' to enable passing configMap/secret-KeyRef(s) as environment variables to CodiMD"
+  artifacthub.io/images: |
+    - name: hackmd
+      image: nabo.codimd.dev/hackmdio/hackmd:2.3.2

--- a/charts/codimd/Chart.yaml
+++ b/charts/codimd/Chart.yaml
@@ -18,7 +18,7 @@ kubeVersion: ">=1.14.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/codimd/README.md
+++ b/charts/codimd/README.md
@@ -138,6 +138,8 @@ If you want use ingress, please set `service.type` to be `ClusterIP`
 | codimd.markdown.useHardBreak                   |                                                                                                           | `true`                       |
 | codimd.markdown.linkifyHeaderStyle             |                                                                                                           | `keep-case`                  |
 | codimd.extraEnvironmentVariables               | Extra environment variable for CodiMD container                                                           | `{}`                         |
+| codimd.extraEnvironmentVariablesFrom           | List of extra environment variable(s) in YAML for CodiMD container, useful for `{configMap,secret}KeyRef` | `[]`                         |
+
 ### CodiMD Authentication Method parameters
 
 | Parameter                                               | Description                                                                                               | Default           |

--- a/charts/codimd/templates/deployment.yaml
+++ b/charts/codimd/templates/deployment.yaml
@@ -135,6 +135,9 @@ spec:
               value: {{ $val | quote }}
             {{ end }}
           {{ end }}
+          {{- if .Values.codimd.extraEnvironmentVariablesFrom }}
+            {{- toYaml .Values.codimd.extraEnvironmentVariablesFrom | nindent 12 }}
+          {{- end }}
           envFrom:
             - secretRef:
                 name: {{ template "codimd.shortName" . }}-auth-env

--- a/charts/codimd/values.yaml
+++ b/charts/codimd/values.yaml
@@ -175,6 +175,18 @@ codimd:
   extraEnvironmentVariables: {}
     # CMD_LOGLEVEL: info
 
+  extraEnvironmentVariablesFrom: []
+    # - name: ENV_FROM
+    #   valueFrom:
+    #     configMapKeyRef:
+    #       name: configmap
+    #       key: configmap_key
+    # - name: SECRET_ENV_FROM
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: secret
+    #       key: secret_key
+
   ## automatically check new version
   versionCheck: true
 


### PR DESCRIPTION
- This can be useful when passing secrets/configuration living on an existing Secret/ConfigMap

```yaml
codimd:
  extraEnvironmentVariablesFrom:
    - name: ENV_FROM
      valueFrom:
        configMapKeyRef:
          name: configmap
          key: configmap_key
    - name: SECRET_ENV
      valueFrom:
        secretKeyRef:
          name: secret
          key: secret_key
```

- Also included `artifacthub.io` annotations to integrate changelogs and security scanning on [ArtifactHub](https://artifacthub.io/packages/helm/codimd/codimd) .[Documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations)