### PR TITLE
Add compatibility with Kubernetes 1.22+

### DIFF
--- a/charts/codimd/templates/ingress.yaml
+++ b/charts/codimd/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "codimd.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
`networking.k8s.io/v1beta1` is deprecated since 1.19 and removed since 1.22. It's replace with `networking.k8s.io/v1`

Fixes #15 