### PR TITLE
Fixed minio image upload InvalidBucketNameError error

### DIFF
--- a/charts/codimd/README.md
+++ b/charts/codimd/README.md
@@ -105,6 +105,7 @@ If you want use ingress, please set `service.type` to be `ClusterIP`
 | codimd.imageUpload.minio.port                  | The minio port                                                                                            | `nil`                        |
 | codimd.imageUpload.minio.accessKey             | The minio access key                                                                                      | `nil`                        |
 | codimd.imageUpload.minio.secretKey             | The minio secret key                                                                                      | `nil`                        |
+| codimd.imageUpload.minio.bucket                | The minio bucket name                                                                                     | `nil`                        |
 | codimd.imageUpload.s3.endpoint                 | The AWS s3 endpoint                                                                                       | `nil`                        |
 | codimd.imageUpload.s3.region                   | The AWS s3 region                                                                                         | `nil`                        |
 | codimd.imageUpload.s3.accessKeyId              | The AWS s3 access key                                                                                     | `nil`                        |

--- a/charts/codimd/templates/image-upload-secret.yaml
+++ b/charts/codimd/templates/image-upload-secret.yaml
@@ -37,6 +37,7 @@ stringData:
   CMD_MINIO_ENDPOINT: {{ default "" .Values.codimd.imageUpload.minio.endpoint | quote }}
   CMD_MINIO_SECURE: {{ default "true" .Values.codimd.imageUpload.minio.secure | quote }}
   CMD_MINIO_PORT: {{ default "" .Values.codimd.imageUpload.minio.port | quote }}
+  CMD_S3_BUCKET: {{ default "" .Values.codimd.imageUpload.minio.bucket | quote }}
   {{ end }}
   {{ end }}
 

--- a/charts/codimd/values.yaml
+++ b/charts/codimd/values.yaml
@@ -157,6 +157,7 @@ codimd:
   #      port:
   #      accessKey:
   #      secretKey:
+  #      bucket:
   #    s3:
   #      endpoint:
   #      region:


### PR DESCRIPTION
Add new attribute `codimd.imageUpload.minio.bucket`  link to secret environment `CMD_S3_BUCKET`

Before this fix, must define bucket name in `s3` attributes and with one fake `accessKeyId` like below.

```
codimd:
  (....)
  imageUpload:
    storeType: minio
    minio:
      endpoint: minio-host
      secure: false
      port: 9000
      accessKey: abcd1234
      secretKey: abcd1234
    s3:
      accessKeyId: fake_id_here
      bucket: codimd
```

This PR  add ` bucket` to minio attributes to fix this prob

```
codimd:
  (....)
  imageUpload:
    storeType: minio
    minio:
      endpoint: minio_host
      secure: false
      port: 9000
      accessKey: abcd1234
      secretKey: abcd1234
      bucket: codimd
```