### PR TITLE
Improved helm chart Ingress for Kubernetes >1.20 and added more customization for PVC

### DIFF
--- a/charts/codimd/Chart.yaml
+++ b/charts/codimd/Chart.yaml
@@ -18,7 +18,7 @@ kubeVersion: ">=1.14.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/codimd/README.md
+++ b/charts/codimd/README.md
@@ -111,10 +111,12 @@ If you want use ingress, please set `service.type` to be `ClusterIP`
 | codimd.imageUpload.s3.secretKey                | The AWS s3 secret key                                                                                     | `nil`                        |
 | codimd.imageUpload.s3.bucket                   | The AWS s3 bucket name                                                                                    | `nil`                        |
 | codimd.imageStorePersistentVolume.enabled      | Enable image persistence using PVC                                                                        | `true`                       |
+| codimd.imageStorePersistentVolume.persistentVolumeClaimName | Use existing PVC with given name instead of creating own                                     | `nil`                        |
 | codimd.imageStorePersistentVolume.size         | The size of persistence volume                                                                            | `10Gi`                       |
 | codimd.imageStorePersistentVolume.storageClass | The storageClass of persistence volume                                                                    | `-`                          |
 | codimd.imageStorePersistentVolume.accessModes  | The accessModes of persistence volume                                                                     | [`ReadWriteOnce`]            |
 | codimd.imageStorePersistentVolume.volumeMode   | The volumeMode of persistence volume                                                                      | `Filesystem`                 |
+| codimd.imageStorePersistentVolume.keepPvc      | Keep PVC when helm chart is uninstalled                                                                   | `false`                      |
 | codimd.versionCheck                            | Enable automatically version checker                                                                      | `true`                       |
 | codimd.security.useCDN                         | Whether CodiMD would use static assets served on CDN                                                      | `false`                      |
 | codimd.security.sessionSecret                  | The secret string to sign session, please must change this value                                          | `changeit`                   |

--- a/charts/codimd/templates/deployment.yaml
+++ b/charts/codimd/templates/deployment.yaml
@@ -177,6 +177,11 @@ spec:
       {{ if .Values.codimd.imageStorePersistentVolume.enabled }}
       volumes:
         - name: image-store
+        {{- if .Values.codimd.imageStorePersistentVolume.persistentVolumeClaimName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.codimd.imageStorePersistentVolume.persistentVolumeClaimName }}
+        {{- else }}      
           persistentVolumeClaim:
             claimName: {{ template "codimd.fullname" . }}
+        {{- end }}
       {{ end }}

--- a/charts/codimd/templates/ingress.yaml
+++ b/charts/codimd/templates/ingress.yaml
@@ -1,10 +1,15 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "codimd.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- $apiVersion := .Capabilities.APIVersions -}}
+{{- if $apiVersion.Has "networking.k8s.io/v1" }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+{{- if $apiVersion.Has "networking.k8s.io/v1beta1" }}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 {{- end }}
 kind: Ingress
 metadata:
@@ -33,9 +38,18 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            {{- if $apiVersion.Has "networking.k8s.io/v1" }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+            {{- else }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: {{ $svcPort }}
+            {{- end }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/codimd/templates/pvc.yaml
+++ b/charts/codimd/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.codimd.imageStorePersistentVolume.persistentVolumeClaimName }}
 {{ if .Values.codimd.imageStorePersistentVolume.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -6,6 +7,10 @@ metadata:
   labels:
     app.kubernetes.io/component: pvc
   {{- include "codimd.labels" . | nindent 4}}
+  {{- if .Values.codimd.imageStorePersistentVolume.keepPvc }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}  
 spec:
   accessModes:
     {{ range .Values.codimd.imageStorePersistentVolume.accessModes }}
@@ -17,3 +22,4 @@ spec:
       storage: {{ default "10G" .Values.codimd.imageStorePersistentVolume.size | quote }}
   {{- include "codimd.storageClass" . | nindent 2 }}
   {{ end }}
+{{- end }}

--- a/charts/codimd/values.yaml
+++ b/charts/codimd/values.yaml
@@ -170,7 +170,8 @@ codimd:
     accessModes:
       - ReadWriteOnce
     volumeMode: Filesystem
-
+    keepPvc: 'false'
+  
   ## for advanced used, manually setup environment for used
   extraEnvironmentVariables: {}
     # CMD_LOGLEVEL: info


### PR DESCRIPTION
I improved the ingress of the chart to be compatible with Kubernetes >1.20 which only supports ingress v1 and removed deprecated v1beta1 api.
I also added the option to keep the PVC when helm chart is uninstalled and as alternative use an existing PVC with given name instead of creating own during first chart installation.