### PR TITLE
fix(codimd): update codimd from 2.3.2 to 2.4.2

### DIFF
--- a/charts/codimd/Chart.yaml
+++ b/charts/codimd/Chart.yaml
@@ -18,8 +18,8 @@ kubeVersion: ">=1.14.0-0"
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.3.2
+appVersion: 2.4.2

--- a/charts/codimd/values.yaml
+++ b/charts/codimd/values.yaml
@@ -11,7 +11,8 @@ image:
   repository: "hackmdio/hackmd"
   # When you use export pdf with CJK character, please change the tag with postfix `-cjk`.
   # for example 2.2.0-cjk
-  tag: "2.3.2"
+  # If not set this defaults to the appVersion in Chart.yaml
+  tag: ""
   pullPolicy: IfNotPresent
   pullSecrets: []
 #    - myRegistryKeySecretName


### PR DESCRIPTION
In addition to bumping the value in `Chart.yaml` i'm also removing it from `values.yaml` so the helper that defaults to using `appVersion` can do it's thing.

https://github.com/hackmdio/codimd-helm/blob/9728ae565ddb83c5fb4d46eb197cf465cfe09df8/charts/codimd/templates/_helpers.tpl#L52-L57